### PR TITLE
Issue/7 support net standard 2.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.1.10.{build}
+version: 2.0.0.{build}
 
 install:
     - nuget restore

--- a/fluentOptionals.Tests/OptionalTests.cs
+++ b/fluentOptionals.Tests/OptionalTests.cs
@@ -38,8 +38,7 @@ namespace FluentOptionals.Tests
         public void ToSome_WhenNullIsGiven_ThenSomeCreationFailedExceptionGetsThrown()
         {
             Action nullToSome = () => ((object) null).ToSome();
-
-            nullToSome.ShouldThrow<SomeCreationOfNullException>();
+            nullToSome.Should().Throw<SomeCreationOfNullException>();
         }
 
         #endregion
@@ -203,7 +202,7 @@ namespace FluentOptionals.Tests
         {
             Action noneThrowsException = () => _none.ValueOrThrow(new TestException());
 
-            noneThrowsException.ShouldThrow<Exception>();
+            noneThrowsException.Should().Throw<Exception>();
         }
 
         #endregion

--- a/fluentOptionals.Tests/fluentOptionals.Tests.csproj
+++ b/fluentOptionals.Tests/fluentOptionals.Tests.csproj
@@ -1,110 +1,23 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{95A08A3F-C304-4459-A9EF-C62F16A348F5}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>FluentOptionals.Tests</RootNamespace>
-    <AssemblyName>FluentOptionals.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
-    <IsCodedUITest>False</IsCodedUITest>
-    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.14.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.14.0\lib\net45\FluentAssertions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.14.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.14.0\lib\net45\FluentAssertions.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.4.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
+    <PackageReference Include="fluentassertions" Version="5.10.3" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
   </ItemGroup>
-  <Choose>
-    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-      </ItemGroup>
-    </When>
-    <Otherwise />
-  </Choose>
+
   <ItemGroup>
-    <Compile Include="Compositions\Optional7Tests.cs" />
-    <Compile Include="Compositions\Optional6Tests.cs" />
-    <Compile Include="Compositions\Optional5Tests.cs" />
-    <Compile Include="Compositions\Optional4Tests.cs" />
-    <Compile Include="Compositions\Optional3Tests.cs" />
-    <Compile Include="Compositions\Optional2Tests.cs" />
-    <Compile Include="FluentAssertionExtensions.cs" />
-    <Compile Include="OptionalTests.cs" />
-    <Compile Include="Linq\OptionalEnumerableExtensionsTests.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <ProjectReference Include="..\fluentOptionals\fluentOptionals.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\fluentOptionals\FluentOptionals.csproj">
-      <Project>{A1DBD4A0-0B9B-48D8-9C95-4D291AFAF391}</Project>
-      <Name>FluentOptionals</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+<PropertyGroup>
+   <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+</PropertyGroup>
+
 </Project>

--- a/fluentOptionals/fluentOptionals.csproj
+++ b/fluentOptionals/fluentOptionals.csproj
@@ -1,10 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-<PropertyGroup>
-<TargetFramework>netstandard2.1</TargetFramework>
+<PropertyGroup Label="Configuration">
+   <SignAssembly>True</SignAssembly>
+   <DelaySign>False</DelaySign>
 </PropertyGroup>
+
+<PropertyGroup>
+   <TargetFramework>netstandard2.1</TargetFramework>
+   <PackageId>FluentOptionals</PackageId>
+   <PackageVersion>1.0.0</PackageVersion>
+   <Authors>David Leitner</Authors>
+   <Description>A lightweight &amp; fluent Option/Optional/Maybe Implementation supporting .NET Standard</Description>
+   <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+   <PackageReleaseNotes>$releseNote$</PackageReleaseNotes>
+   <PackageTags>optionals, maybe, option</PackageTags>
+   <ProjectUrl>https://github.com/duffleit/fluentOptionals</ProjectUrl>
+</PropertyGroup>
+
 <PropertyGroup>
    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+</PropertyGroup>
+
+<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+   <AssemblyOriginatorKeyFile>fluentOptionals.snk</AssemblyOriginatorKeyFile>
 </PropertyGroup>
 
 </Project>

--- a/fluentOptionals/fluentOptionals.csproj
+++ b/fluentOptionals/fluentOptionals.csproj
@@ -8,7 +8,7 @@
 <PropertyGroup>
    <TargetFramework>netstandard2.1</TargetFramework>
    <PackageId>FluentOptionals</PackageId>
-   <PackageVersion>1.0.0</PackageVersion>
+   <PackageVersion>2.0.0</PackageVersion>
    <Authors>David Leitner</Authors>
    <Description>A lightweight &amp; fluent Option/Optional/Maybe Implementation supporting .NET Standard</Description>
    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/fluentOptionals/fluentOptionals.csproj
+++ b/fluentOptionals/fluentOptionals.csproj
@@ -1,69 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{A1DBD4A0-0B9B-48D8-9C95-4D291AFAF391}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>FluentOptionals</RootNamespace>
-    <AssemblyName>FluentOptionals</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>fluentOptionals.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Composition\CompositeHelpers.cs" />
-    <Compile Include="SomeCreationWithNullException.cs" />
-    <Compile Include="OptionalCreateExtensions.cs" />
-    <Compile Include="OptionalTransformations.cs" />
-    <Compile Include="Optional.cs" />
-    <Compile Include="Composition\Optional7.cs" />
-    <Compile Include="Composition\Optional6.cs" />
-    <Compile Include="Composition\Optional5.cs" />
-    <Compile Include="Composition\Optional4.cs" />
-    <Compile Include="Composition\Optional3.cs" />
-    <Compile Include="Composition\Optional2.cs" />
-    <Compile Include="Linq\OptionalEnumerableExtensions.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="fluentOptionals.snk" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+<PropertyGroup>
+<TargetFramework>netstandard2.1</TargetFramework>
+</PropertyGroup>
+<PropertyGroup>
+   <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+</PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Fixing the issue https://github.com/duffleit/fluentOptionals/issues/7. I updated fluentOptionals.csproj to the new csproj SDK format. Also updated to .NetStandard 2.1. Testproject has been updated to .Net core 3.1 (and also to new csproj SDK).

Increased version in appveyor.yml to 2.0.0.x, thought would be a good idea since the target framework changed.